### PR TITLE
Add fingerprint system

### DIFF
--- a/slyther
+++ b/slyther
@@ -9,6 +9,7 @@ from src.ui import *
 from src.keys import login
 import src.socks as socks
 from src.contacts import load_contacts, save_contacts, display_contact, display_convo, display_messages
+from src.fingerprints import create_fingerprint 
 
 
 class Application:
@@ -38,6 +39,7 @@ class Application:
                     "nc": self.new_contact, 
                     "lc": self.list_contacts,
                     "dc": self.delete_contact,
+                    "fp": self.get_fingerprint,
                     "c" : self.clear_screen,
                     "h" : self.display_help,
                     "q" : self.quit 
@@ -56,22 +58,39 @@ class Application:
         print_bar("VIEW CONVERSATION")
         display_messages(contacts)
         contact_id = get_recipient(contacts)
+        verify_fingerprints = True
 
         while True:
-            display_convo(contacts[contact_id])
-            message = input("Message: ").encode()
             contacts = load_contacts(self.private)
+            display_convo(contacts[contact_id])
+
+            if not verify_fingerprints:
+                print_yellow("Fingerprint verification disabled.")
+            message = input("Message: ").encode()
 
             if len(message.decode()) > 0:
                 try:
-                    socks.transmit(contacts[contact_id], message, self.public, self.private)
+                    socks.transmit(contacts[contact_id], message, self.public, self.private, check_fingerprint=verify_fingerprints)
                 
                 except socket.error as e:
                     print_red("Error: Failed to connect to contact. Transmission cancelled.\n")
                     break
+                
                 except socket.timeout:
                     print_red("Error: Connection timed out. Transmission incomplete.\n")
                     break
+
+                except AssertionError:
+                    print_yellow("\nWARNING: Contact fingerprint does not match. Transmission cancelled.")
+                    print("Either your contact has changed keys, or something may be going on.")
+                    print("Confirm with them over a secure channel.\n")
+
+                    if confirm("Temporarily disable fingerprint verification? (Y/n) "):
+                        verify_fingerprints = False
+                    else:
+                        print_green("Aborted.\n")
+                        break
+
                 else:
                     message_receipt = { "time": datetime.now().strftime("%m/%d/%y %I:%M%p"), 
                                         "recieved": False, 
@@ -150,6 +169,13 @@ class Application:
             display_contact(contact_id, contacts)
 
 
+    def get_fingerprint(self):
+        print_bar("PUBLIC FINGERPRINT")
+        print_yellow("Copy and paste the following fingerprint into trusted channels only.\n")
+        print(create_fingerprint(self.public))
+        print()
+    
+
     def clear_screen(self):
         run(["clear"])
 
@@ -161,6 +187,7 @@ class Application:
         print("nc   -> New/Update Contact")
         print("lc   -> List Contacts")
         print("dc   -> Delete Contact")
+        print("fp   -> Display Fingerprint")
         print("c    -> Clear Screen")
         print("h    -> Display help")
         print("q    -> Quit slyther\n")

--- a/slyther-server
+++ b/slyther-server
@@ -7,6 +7,7 @@ from src.socks import receive, receive_session, receive_aes, send, PORT
 from src.keys import login
 from src.contacts import load_contacts, save_contacts
 from src.ui import *
+from src.fingerprints import create_fingerprint, verify_fingerprint
 
 
 def print_banner():
@@ -17,20 +18,20 @@ def print_banner():
     print_green("/////////////////////")
 
 
-def get_contact_name(ip, contacts):
+def get_contact_id(ip, contacts):
     """
-    Given an IP address, finds the corresponding contact name.
+    Given an IP address, finds the corresponding contact ID.
 
     Args:
         ip: The ip address to match with a contact name.
         contacts: The contacts dictionary to search.
 
     Return:
-        The name of the contact if the IP is known, otherwise the IP.
+        The ID of the contact if the IP is known, otherwise the IP.
     """
     for contact_id in contacts:
         if contacts[contact_id]["ip"] == ip:
-            return contacts[contact_id]["name"]
+            return contact_id
     return ip
 
 
@@ -44,47 +45,65 @@ def handle_client(sock, addr, public, private):
         public: The public key of this user.
         private: The private key of this user.
     """
-    print("Handling client")
     contacts = load_contacts(private)
-    display_name = get_contact_name(addr[0], contacts)
-    print_green("New connection from {}!".format(display_name))
+    contact_id = get_contact_id(addr[0], contacts)
     
-    print(" > Performing key exchange...")
-    client_public = RSA.import_key(receive(sock))
-    print("    :  Received public key.")
-    send(sock, public.export_key())
-    print("    :  Sent public key.")
-
-    print(" > Receiving message...")
+    if contact_id in contacts:
+        print_green("New connection from {}!".format(contacts[contact_id]["name"]))
+    else:
+        print_green("New connection from {}!".format(contact_id))
+    
     try:
+        print(" > Performing key exchange...")
+        client_public = RSA.import_key(receive(sock))
+        print("    : Received public key.")
+        
+        # Check fingerprint
+        trusted = True
+        if contact_id in contacts:
+            if not verify_fingerprint(client_public, contacts[contact_id]["fingerprint"]):
+                print_yellow("    : Fingerprint mismatch. Untrusted.")
+
+        send(sock, public.export_key())
+        print("    : Sent public key.")
+
+        print(" > Receiving message...")
         session_key = receive_session(sock, client_public, private)
         print("    : Received session key.")
         message = receive_aes(sock, client_public, session_key)
         print("    : Received message.")
     except ValueError as e:
-        print_red("Error receiving message.")
+        print_red("    : Error receiving message.")
         print(e)
+    except OSError:
+        print_red("    : Connection lost. Message not recieved.")
     else:
         print(" > Storing message...")
-        message_receipt = { "time": datetime.now().strftime("%m/%d/%y %I:%M%p"), 
-                            "recieved": True,
-                            "contents": message.decode() }
 
-        sender_id = 0
-        for contact_id in contacts:
-            if display_name == contacts[contact_id]["name"]:
-                sender_id = contact_id
+        # Add warning if fingerprint does not match
+        trusted = True
+        if contact_id in contacts:
+            if verify_fingerprint(client_public, contacts[contact_id]["fingerprint"]):
+                message_receipt = { "time": datetime.now().strftime("%m/%d/%y %I:%M%p"), 
+                                    "recieved": True,
+                                    "contents": "!UNTRUSTED! {} !UNTRUSTED!".format(message.decode()) }
 
-        if sender_id:
-            contacts[sender_id]["messages"].append(message_receipt)
+            else:
+                message_receipt = { "time": datetime.now().strftime("%m/%d/%y %I:%M%p"), 
+                                    "recieved": True,
+                                    "contents": message.decode() }
+
+        if contact_id in contacts:
+            contacts[contact_id]["messages"].append(message_receipt)
         else:
-            contacts[display_name] = {  "name": display_name,
+            contacts[contact_id] = {  "name": contact_id,
                                         "ip": addr[0],
-                                        "fingerprint": None,    # Tweak when fingerprint time
+                                        "fingerprint": create_fingerprint(client_public),
                                         "messages": [message_receipt]}
+
         save_contacts(contacts, private)
     finally:
-        print(" > Closing connection...")
+        print(" > Closing connection...\n")
         sock.close()
         
 
@@ -106,7 +125,6 @@ if __name__ == "__main__":
             while True:
                 try:
                     connection, addr = sock.accept()
-                    print("Connection")
                     connection_thread = Thread( target=handle_client, 
                                                 args=(connection, addr, public, private))
                     connection_thread.start()

--- a/slyther-server
+++ b/slyther-server
@@ -59,7 +59,6 @@ def handle_client(sock, addr, public, private):
         print("    : Received public key.")
         
         # Check fingerprint
-        trusted = True
         if contact_id in contacts:
             if not verify_fingerprint(client_public, contacts[contact_id]["fingerprint"]):
                 print_yellow("    : Fingerprint mismatch. Untrusted.")
@@ -80,20 +79,15 @@ def handle_client(sock, addr, public, private):
     else:
         print(" > Storing message...")
 
-        # Add warning if fingerprint does not match
-        trusted = True
+        message_receipt = { "time": datetime.now().strftime("%m/%d/%y %I:%M%p"), 
+                            "recieved": True,
+                            "contents": message.decode() }
         if contact_id in contacts:
-            if verify_fingerprint(client_public, contacts[contact_id]["fingerprint"]):
+            # Edit message if untrusted 
+            if not verify_fingerprint(client_public, contacts[contact_id]["fingerprint"]):
                 message_receipt = { "time": datetime.now().strftime("%m/%d/%y %I:%M%p"), 
                                     "recieved": True,
                                     "contents": "!UNTRUSTED! {} !UNTRUSTED!".format(message.decode()) }
-
-            else:
-                message_receipt = { "time": datetime.now().strftime("%m/%d/%y %I:%M%p"), 
-                                    "recieved": True,
-                                    "contents": message.decode() }
-
-        if contact_id in contacts:
             contacts[contact_id]["messages"].append(message_receipt)
         else:
             contacts[contact_id] = {  "name": contact_id,

--- a/src/fingerprints.py
+++ b/src/fingerprints.py
@@ -1,0 +1,36 @@
+from Crypto.Hash import BLAKE2b
+from Crypto.PublicKey import RSA
+from base64 import b32encode, b32decode
+from zlib import compress
+
+def create_fingerprint(key):
+    """
+    Generates and returns a fingerprint for a given key.
+
+    Args:
+        key: The Crypto.PublicKey.RSA.RsaKey to fingerprint.
+
+    Returns:
+        The fingerprint of the key.
+    """
+    hasher = BLAKE2b.new(digest_bits=256)
+    hasher.update(key.export_key())
+    hash_bytes = hasher.digest()
+    b32 = b32encode(hash_bytes)
+    fingerprint = "-".join(b32[n:n+4].decode() for n in range(0, len(b32), 4))
+    return fingerprint[:-5]
+    
+
+def verify_fingerprint(key, fingerprint):
+    """
+    Returns true if a key's fingerprint is equal to another fingerprint.
+
+    Args:
+        key: The Crypto.PublicKey.RSA.RsaKey to compare.
+        fingerprint: The fingerprint to check against.
+
+    Returns:
+        True if the key matches the fingerprint, false otherwise.
+    """
+    return create_fingerprint(key) == fingerprint
+


### PR DESCRIPTION
This PR adds a fingerprint system so that users can exchange fingerprints through trusted channels in order to check for unexpected key changes.

This fixes #2 

### The fingerprints
The fingerprints are hyphen-separated quartets of `base32` data, so that fingerprints are easily copied and pasted as well as read or heard.

For example:
`ZBN4-3KBD-3Q5E-FKCB-XJPQ-5XXU-RJBU-JQ2D-BEWZ-33LG-CER2-XM2W-CTNQ`

The fingerprints are based on the BLAKE2b hash of the contact's public key. BLAKE2b was chosen for its preimage and collision resistance (more details [here](https://crypto.stackexchange.com/questions/45127/should-i-use-sha256-or-blake2-to-checksum-and-sign-scrypt-headers)).

### New behavior
When a user attempts to send a message to someone whose fingerprint doesn't match their public key, their message is cancelled, and they are allowed the choice to disable fingerprint verification or abort.

When the server recieves a message from a contact with a mismatched fingerprint, the server flags all messages recieved under the mismatch with `!UNTRUSTED!` labels.
